### PR TITLE
Symlink clangd in /usr/bin

### DIFF
--- a/lsp-docker-langservers/Dockerfile
+++ b/lsp-docker-langservers/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update \
 
 # C-Family
 COPY --from=ccls /ccls /ccls
-RUN ln -s /ccls/Release/ccls /usr/bin/ccls
+RUN ln -s /ccls/Release/ccls /usr/bin/ccls \
+	&& ln -s /ccls/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04/bin/clangd /usr/bin/clangd
 
 # Go
 COPY --from=go /go /go


### PR DESCRIPTION
close #43.

[I know  you will change the docker image](https://github.com/emacs-lsp/lsp-docker/issues/44#issuecomment-868972424).
This patch is for the old one. But I thought this might help others using the package until the image is changed and I opened this PR.

If you think this PR is not necessary, please close it.