### PR TITLE
chore: Install npm from nodesource

### DIFF
--- a/lsp-docker-langservers/Dockerfile
+++ b/lsp-docker-langservers/Dockerfile
@@ -34,7 +34,16 @@ ENV PATH "${PATH}:/go/bin:/root/go/bin"
 RUN /go/bin/go get -u golang.org/x/tools/gopls
 
 # NPM installed language servers
-RUN apt-get install -y npm \
+# https://github.com/nodesource/distributions/blob/master/README.md
+RUN apt-get update \
+	&& apt-get upgrade -y  \
+	&& apt-get install -y wget gnupg2 \
+  && wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
+  && VERSION="node_8.x" \
+  && DISTRO="bionic" \
+  && echo "deb https://deb.nodesource.com/$VERSION $DISTRO main" | tee /etc/apt/sources.list.d/nodesource.list \
+  && echo "deb-src https://deb.nodesource.com/$VERSION $DISTRO main" | tee -a /etc/apt/sources.list.d/nodesource.list \
+  && apt-get update -y && apt-get -y install nodejs \
 	&& npm i -g \
 	bash-language-server \
 	vscode-css-languageserver-bin \


### PR DESCRIPTION
since the Ubuntu repo for 18.04 may not have a sufficiently recent version of node, installing from nodesource as per https://github.com/nodesource/distributions/blob/master/README.md provides a bit more control.

Made this change because the Dockerfile was failing on my setup with:

```
Processing triggers for libc-bin (2.27-3ubuntu1.4) ...
npm WARN deprecated request-promise-native@1.0.9: request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated left-pad@1.3.0: use String.prototype.padStart()
WARN engine fs-extra@10.0.0: wanted: {"node":">=12"} (current: {"node":"8.10.0","npm":"3.5.2"})
WARN engine tempy@1.0.1: wanted: {"node":">=10"} (current: {"node":"8.10.0","npm":"3.5.2"})
npm ERR! Linux 5.10.47
npm ERR! argv "/usr/bin/node" "/usr/bin/npm" "i" "-g" "bash-language-server" "vscode-css-languageserver-bin" "vscode-html-languageserver-bin" "dockerfile-language-server-nodejs" "typescript-language-server" "typescript"
npm ERR! node v8.10.0
npm ERR! npm  v3.5.2
npm ERR! code EMISSINGARG

npm ERR! typeerror Error: Missing required argument #1
npm ERR! typeerror     at andLogAndFinish (/usr/share/npm/lib/fetch-package-metadata.js:31:3)
npm ERR! typeerror     at fetchPackageMetadata (/usr/share/npm/lib/fetch-package-metadata.js:51:22)
npm ERR! typeerror     at resolveWithNewModule (/usr/share/npm/lib/install/deps.js:456:12)
npm ERR! typeerror     at /usr/share/npm/lib/install/deps.js:457:7
npm ERR! typeerror     at /usr/share/npm/node_modules/iferr/index.js:13:50
npm ERR! typeerror     at /usr/share/npm/lib/fetch-package-metadata.js:37:12
npm ERR! typeerror     at addRequestedAndFinish (/usr/share/npm/lib/fetch-package-metadata.js:82:5)
npm ERR! typeerror     at returnAndAddMetadata (/usr/share/npm/lib/fetch-package-metadata.js:117:7)
npm ERR! typeerror     at pickVersionFromRegistryDocument (/usr/share/npm/lib/fetch-package-metadata.js:134:20)
npm ERR! typeerror     at /usr/share/npm/node_modules/iferr/index.js:13:50
npm ERR! typeerror This is an error with npm itself. Please report this error at:
npm ERR! typeerror     <http://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /npm-debug.log
The command '/bin/sh -c apt-get install -y npm  && npm i -g     bash-language-server    vscode-css-languageserver-bin   vscode-html-languageserver-bin       dockerfile-language-server-nodejs       typescript-language-server      typescript' returned a non-zero code: 1
make: *** [Makefile:5: all] Error 1
```