### PR TITLE
Add support for persisting configurations

### DIFF
--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -253,7 +253,7 @@ the docker container to run the language server."
   "Get the LSP configuration based on a project-local configuration (using lsp-mode)"
   (let ((project-config-file-path (if (f-exists? (f-join (lsp-workspace-root) ".lsp-docker.yml"))
                                        (f-join (lsp-workspace-root) ".lsp-docker.yml")
-                                     ((f-join (lsp-workspace-root) ".lsp-docker.yaml")))))
+                                    (f-join (lsp-workspace-root) ".lsp-docker.yaml"))))
     (lsp-docker-get-config-from-project-config-file project-config-file-path)))
 
 (defvar lsp-docker-supported-server-types-subtypes

--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -251,10 +251,9 @@ the docker container to run the language server."
 
 (defun lsp-docker-get-config-from-lsp ()
   "Get the LSP configuration based on a project-local configuration (using lsp-mode)"
-  (let* ((normalized-project-root (file-name-as-directory (lsp-workspace-root)))
-         (project-config-file-path (if (f-exists? (concat normalized-project-root ".lsp-docker.yml"))
-                                       (concat normalized-project-root ".lsp-docker.yml")
-                                     ((concat normalized-project-root ".lsp-docker.yaml")))))
+  (let ((project-config-file-path (if (f-exists? (f-join (lsp-workspace-root) ".lsp-docker.yml"))
+                                       (f-join (lsp-workspace-root) ".lsp-docker.yml")
+                                     ((f-join (lsp-workspace-root) ".lsp-docker.yaml")))))
     (lsp-docker-get-config-from-project-config-file project-config-file-path)))
 
 (defvar lsp-docker-supported-server-types-subtypes

--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -344,7 +344,7 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
         (if (and (lsp-docker-check-server-type-subtype lsp-docker-supported-server-types-subtypes server-type-subtype)
                  (lsp-docker-check-path-mappings path-mappings))
             (let ((container-type (car server-type-subtype))
-                    (container-subtype (cdr server-type-subtype)))
+                  (container-subtype (cdr server-type-subtype)))
                 (pcase container-type
                   ('docker (pcase container-subtype
                              ('image (lsp-docker-register-client-with-activation-fn

--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -393,9 +393,6 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
                                (cl-incf docker-container-name-suffix)
                              docker-container-name-suffix))
                  docker-container-name))
-              (actual-server-command (if server-command
-                                         server-command
-                                       (lsp--client-))))
           (setf (lsp--client-server-id client) docker-server-id
                 (lsp--client-uri->path-fn client) (-partial #'lsp-docker--uri->path
                                                             path-mappings

--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -316,7 +316,7 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
            docker-container-name)
    " "))
 
-(defmacro create-lsp-docker-activation-function-by-project-dir (project-dir)
+(defmacro lsp-docker-create-activation-function-by-project-dir (project-dir)
   `(lambda (&rest unused)
      (let ((current-project-root (lsp-workspace-root))
            (registered-project-root ,project-dir))
@@ -354,7 +354,7 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
                                       :docker-image-id server-image-name
                                       :docker-container-name server-container-name
                                       :docker-container-name-suffix nil
-                                      :activation-fn (create-lsp-docker-activation-function-by-project-dir (lsp-workspace-root))
+                                      :activation-fn (lsp-docker-create-activation-function-by-project-dir (lsp-workspace-root))
                                       :priority lsp-docker-default-priority
                                       :server-command server-launch-command
                                       :launch-server-cmd-fn #'lsp-docker-launch-new-container))
@@ -365,7 +365,7 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
                                           :docker-image-id nil
                                           :docker-container-name server-container-name
                                           :docker-container-name-suffix nil
-                                          :activation-fn (create-lsp-docker-activation-function-by-project-dir (lsp-workspace-root))
+                                          :activation-fn (lsp-docker-create-activation-function-by-project-dir (lsp-workspace-root))
                                           :priority lsp-docker-default-priority
                                           :server-command server-launch-command
                                           :launch-server-cmd-fn #'lsp-docker-launch-existing-container))))))

--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -384,33 +384,33 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
                                                               launch-server-cmd-fn)
   "Registers docker clients with lsp (by persisting configuration)"
   (if-let ((client (copy-lsp--client (gethash server-id lsp-clients))))
-      (progn
-        (let ((docker-container-name-full
-               (if docker-container-name-suffix
-                   (format "%s-%d"
-                           docker-container-name
-                           (if (numberp docker-container-name-suffix)
-                               (cl-incf docker-container-name-suffix)
-                             docker-container-name-suffix))
-                 docker-container-name))
-          (setf (lsp--client-server-id client) docker-server-id
-                (lsp--client-uri->path-fn client) (-partial #'lsp-docker--uri->path
-                                                            path-mappings
-                                                            docker-container-name-full)
-                (lsp--client-activation-fn client) activation-fn
-                (lsp--client-path->uri-fn client) (-partial #'lsp-docker--path->uri path-mappings)
-                (lsp--client-new-connection client) (plist-put
-                                                     (lsp-stdio-connection
-                                                      (lambda ()
-                                                        (funcall (or launch-server-cmd-fn #'lsp-docker-launch-new-container)
-                                                                 docker-container-name-full
-                                                                 path-mappings
-                                                                 docker-image-id
-                                                                 server-command)))
-                                                     :test? (lambda (&rest _)
-                                                              t))
-                (lsp--client-priority client) (or priority (lsp--client-priority client))))
-        (lsp-register-client client))
+      (let ((docker-container-name-full
+             (if docker-container-name-suffix
+                 (format "%s-%d"
+                         docker-container-name
+                         (if (numberp docker-container-name-suffix)
+                             (cl-incf docker-container-name-suffix)
+                           docker-container-name-suffix))
+               docker-container-name)))
+        (setf (lsp--client-server-id client) docker-server-id
+              (lsp--client-uri->path-fn client) (-partial #'lsp-docker--uri->path
+                                                          path-mappings
+                                                          docker-container-name-full)
+              (lsp--client-activation-fn client) activation-fn
+              (lsp--client-path->uri-fn client) (-partial #'lsp-docker--path->uri path-mappings)
+              (lsp--client-new-connection client) (plist-put
+                                                   (lsp-stdio-connection
+                                                    (lambda ()
+                                                      (funcall (or launch-server-cmd-fn #'lsp-docker-launch-new-container)
+                                                               docker-container-name-full
+                                                               path-mappings
+                                                               docker-image-id
+                                                               server-command)))
+                                                   :test? (lambda (&rest _)
+                                                            t))
+              (lsp--client-priority client) (or priority (lsp--client-priority client)))
+        (lsp-register-client client)
+        (message "Registered a language server with id: %s and container name: %s" docker-server-id docker-container-name-full))
     (user-error "No such client %s" server-id)))
 
 (provide 'lsp-docker)

--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -324,11 +324,6 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
            (registered-project-root ,project-dir))
        (f-same? current-project-root registered-project-root))))
 
-(defun test-create-lsp-docker-activation-function-by-project-dir ()
-  (interactive)
-  (create-lsp-docker-activation-function-by-project-dir))
-
-
 (defun lsp-docker-generate-docker-server-id (config project-root)
   "Generate the docker-server-id from the project config"
   (let ((lsp-docker-original-server-id (symbol-name (lsp-docker-get-server-id config)))

--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -318,7 +318,6 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
 
 (defmacro create-lsp-docker-activation-function-by-project-dir (project-dir)
   `(lambda (&rest unused)
-     (interactive)
      (let ((current-project-root (lsp-workspace-root))
            (registered-project-root ,project-dir))
        (f-same? current-project-root registered-project-root))))


### PR DESCRIPTION
Adding support for persisting configurations via a config stored in the project root. 

Configs are `yaml` files that are named `.lsp-docker.yml` or `.lsp-docker.yaml` and look like this:
```
lsp:
  server:
    type: docker
    subtype: container # Or image. container subtype means launching an existing container
    # image type means creating a new container each time from a specified image
    name: not-significant-but-unique-name
    server: server-id-of-the-base-server # Server id of a registered server (by lsp-mode) 
    launch_command: "launch command with arguments" # Launch command of the language server
    # (selected by a server id specified above) in stdio mode
  mappings:
    - source: "/your/host/source/path"
      destination: "/your/local/path/inside/a/container"
```

Analysis starts by invoking an interactive function `lsp-docker-register` or `lsp-docker-start` (if you want not only to register the server but to start it immediately after) when you have opened a file from the project you wanted to use a containerized language server with