### PR TITLE
Verify path mappings when using server containers

### DIFF
--- a/README.org
+++ b/README.org
@@ -140,7 +140,7 @@ lsp:
     # (selected by a server id specified above) in stdio mode
     # Note: launch_command is not used with container subtype servers
     # as a command is embedded in a container itself and serves as an entrypoint
-    # Note: config path mappings are compared against an actual container (with container subtype servers):
+    # Note: config path mappings are compared with an actual container (with container subtype servers):
     # container mappings must contain all the config mappings (destination paths inside containers have to be absolute)
   mappings:
     - source: "/your/host/source/path"

--- a/README.org
+++ b/README.org
@@ -140,6 +140,8 @@ lsp:
     # (selected by a server id specified above) in stdio mode
     # Note: launch_command is not used with container subtype servers
     # as a command is embedded in a container itself and serves as an entrypoint
+    # Note: config path mappings are compared against an actual container (with container subtype servers):
+    # container mappings must contain all the config mappings (destination paths inside containers have to be absolute)
   mappings:
     - source: "/your/host/source/path"
       destination: "/your/local/path/inside/a/container"

--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -445,18 +445,20 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
                                       :priority lsp-docker-default-priority
                                       :server-command server-launch-command
                                       :launch-server-cmd-fn #'lsp-docker-launch-new-container))
-                             ('container (lsp-docker-register-client-with-activation-fn
-                                          :server-id regular-server-id
-                                          :docker-server-id server-id
-                                          :path-mappings path-mappings
-                                          :docker-image-id nil
-                                          :docker-container-name server-container-name
-                                          :docker-container-name-suffix nil
-                                          :activation-fn (lsp-docker-create-activation-function-by-project-dir (lsp-workspace-root))
-                                          :priority lsp-docker-default-priority
-                                          :server-command server-launch-command
-                                          :launch-server-cmd-fn #'lsp-docker-launch-existing-container))))))
-          (user-error "Invalid LSP docker config: unsupported server type and/or subtype")))
+                             ('container (if (lsp-docker-verify-path-mappings-against-container path-mappings server-container-name)
+                                             (lsp-docker-register-client-with-activation-fn
+                                              :server-id regular-server-id
+                                              :docker-server-id server-id
+                                              :path-mappings path-mappings
+                                              :docker-image-id nil
+                                              :docker-container-name server-container-name
+                                              :docker-container-name-suffix nil
+                                              :activation-fn (lsp-docker-create-activation-function-by-project-dir (lsp-workspace-root))
+                                              :priority lsp-docker-default-priority
+                                              :server-command server-launch-command
+                                              :launch-server-cmd-fn #'lsp-docker-launch-existing-container)
+                                           (user-error "Container path mappings don't match the config ones!")))))))
+          (user-error "Invalid LSP docker config: unsupported server type and/or subtype or malformed mappings!")))
     (user-error (format "Current file: %s is not in a registered project!" (buffer-file-name)))))
 
 (defun lsp-docker-start ()


### PR DESCRIPTION
A container has to have all the mappings specified in the config in order to prevent undesired behavior (changes in the project that are invisible for the language server)