### PR TITLE
Switch out unmaintained Palantir Python LS for maintained fork

### DIFF
--- a/README.org
+++ b/README.org
@@ -30,7 +30,7 @@
      | Go                    | [[https://golang.org/x/tools/cmd/gopls][gopls]]                             |
      | HTML                  | [[https://github.com/vscode-langservers/vscode-html-languageserver][html]]                              |
      | JavaScript/TypeScript | [[https://github.com/theia-ide/typescript-language-server][typescript-language-server]]        |
-     | Python                | [[https://github.com/palantir/python-language-server][pyls]]                              |
+     | Python                | [[https://github.com/python-lsp/python-lsp-server][pylsp]]                             |
 ** Usage
    There are two ways of working with containerized language servers:
    - 2 containers provided by =lsp-docker=:
@@ -57,7 +57,7 @@
       (require 'lsp-docker)
 
       (defvar lsp-docker-client-packages
-          '(lsp-css lsp-clients lsp-bash lsp-go lsp-pyls lsp-html lsp-typescript
+          '(lsp-css lsp-clients lsp-bash lsp-go lsp-pylsp lsp-html lsp-typescript
             lsp-terraform lsp-clangd))
 
       (setq lsp-docker-client-configs
@@ -67,7 +67,7 @@
             (:server-id dockerfile-ls :docker-server-id dockerfilels-docker :server-command "docker-langserver --stdio")
             (:server-id gopls :docker-server-id gopls-docker :server-command "gopls")
             (:server-id html-ls :docker-server-id htmls-docker :server-command "html-languageserver --stdio")
-            (:server-id pyls :docker-server-id pyls-docker :server-command "pyls")
+            (:server-id pylsp :docker-server-id pyls-docker :server-command "pyls")
             (:server-id ts-ls :docker-server-id tsls-docker :server-command "typescript-language-server --stdio")))
 
       (require 'lsp-docker)

--- a/lsp-docker-langservers/Dockerfile
+++ b/lsp-docker-langservers/Dockerfile
@@ -54,4 +54,4 @@ RUN apt-get update \
 
 # Python
 RUN apt-get install -y python3-pip \
-	&& pip3 install 'python-language-server[all]'
+	&& pip3 install 'python-lsp-server[all]'

--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -138,7 +138,7 @@ Argument SERVER-COMMAND the command to execute inside the running container."
     lsp-go
     lsp-html
     lsp-javascript
-    lsp-pyls)
+    lsp-pylsp)
   "Default list of client packages to load.")
 
 (defvar lsp-docker-default-client-configs
@@ -149,7 +149,7 @@ Argument SERVER-COMMAND the command to execute inside the running container."
    (list :server-id 'dockerfile-ls :docker-server-id 'dockerfilels-docker :server-command "docker-langserver --stdio")
    (list :server-id 'gopls :docker-server-id 'gopls-docker :server-command "gopls")
    (list :server-id 'html-ls :docker-server-id 'htmls-docker :server-command "html-languageserver --stdio")
-   (list :server-id 'pyls :docker-server-id 'pyls-docker :server-command "pyls")
+   (list :server-id 'pylsp :docker-server-id 'pyls-docker :server-command "pylsp")
    (list :server-id 'ts-ls :docker-server-id 'tsls-docker :server-command "typescript-language-server --stdio"))
   "Default list of client configurations.")
 


### PR DESCRIPTION
Closes #47.

The "original" Python language server, `python-language-server` -- originally authored by Palantir -- is no longer maintained; see palantir/python-language-server#935, as well as the fact that there's been no development activity since 2020.

This PR updates all references to point to the community-forked `python-lsp-server` (https://github.com/python-lsp/python-lsp-server).