### PR TITLE
Use smarter activation functions

### DIFF
--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -342,7 +342,7 @@ the docker container to run the language server."
 (defun lsp-docker--get-base-client (config)
   "Get the base lsp client for dockerized client to be built upon"
   (if-let* ((base-server-id (lsp-docker-get-server-id config))
-            (base-client (gethash server-id lsp-clients)))
+            (base-client (gethash base-server-id lsp-clients)))
       base-client
     (user-error "Cannot find a specified base lsp client! Please check the 'server' parameter in the config")))
 

--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -395,8 +395,8 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
   `(lambda (current-file-name current-major-mode)
      (let ((current-project-root (lsp-workspace-root))
            (registered-project-root ,project-dir)
-           (base-activation-fn (lsp--client-activation-fn ,base-lsp-client))
-           (base-major-modes (lsp--client-major-modes ,base-lsp-client)))
+           (base-activation-fn ,(lsp--client-activation-fn base-lsp-client))
+           (base-major-modes ,(lsp--client-major-modes base-lsp-client)))
        (and (f-same? current-project-root registered-project-root)
             (or (if (functionp base-activation-fn)
                     (funcall base-activation-fn current-file-name current-major-mode)
@@ -615,7 +615,8 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
              (path-mappings (lsp-docker-get-path-mappings config (lsp-workspace-root)))
              (regular-server-id (lsp-docker-get-server-id config))
              (server-id (lsp-docker-generate-docker-server-id config (lsp-workspace-root)))
-             (server-launch-command (lsp-docker-get-launch-command config)))
+             (server-launch-command (lsp-docker-get-launch-command config))
+             (base-client (lsp-docker--get-base-client config)))
         (if (and (lsp-docker-check-server-type-subtype lsp-docker-supported-server-types-subtypes server-type-subtype)
                  (lsp-docker-check-path-mappings path-mappings))
             (let ((container-type (car server-type-subtype))
@@ -630,7 +631,7 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
                                         :docker-image-id server-image-name
                                         :docker-container-name server-container-name
                                         :docker-container-name-suffix nil
-                                        :activation-fn (lsp-docker-create-activation-function-by-project-dir (lsp-workspace-root))
+                                        :activation-fn (lsp-docker--create-activation-function-by-project-dir-and-base-client (lsp-workspace-root) base-client)
                                         :priority lsp-docker-default-priority
                                         :server-command server-launch-command
                                         :launch-server-cmd-fn #'lsp-docker-launch-new-container)
@@ -644,7 +645,7 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
                                       :docker-image-id server-image-name
                                       :docker-container-name server-container-name
                                       :docker-container-name-suffix nil
-                                      :activation-fn (lsp-docker-create-activation-function-by-project-dir (lsp-workspace-root))
+                                      :activation-fn (lsp-docker--create-activation-function-by-project-dir-and-base-client (lsp-workspace-root) base-client)
                                       :priority lsp-docker-default-priority
                                       :server-command server-launch-command
                                       :launch-server-cmd-fn #'lsp-docker-launch-new-container)))
@@ -656,7 +657,7 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
                                             :docker-image-id nil
                                             :docker-container-name server-container-name
                                             :docker-container-name-suffix nil
-                                            :activation-fn (lsp-docker-create-activation-function-by-project-dir (lsp-workspace-root))
+                                            :activation-fn (lsp-docker--create-activation-function-by-project-dir-and-base-client (lsp-workspace-root) base-client)
                                             :priority lsp-docker-default-priority
                                             :server-command server-launch-command
                                             :launch-server-cmd-fn #'lsp-docker-launch-existing-container)

--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -385,13 +385,13 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
            docker-container-name)
    " "))
 
-(defmacro lsp-docker-create-activation-function-by-project-dir (project-dir)
+(defun lsp-docker-create-activation-function-by-project-dir (project-dir)
   `(lambda (&rest unused)
      (let ((current-project-root (lsp-workspace-root))
            (registered-project-root ,project-dir))
        (f-same? current-project-root registered-project-root))))
 
-(defmacro lsp-docker--create-activation-function-by-project-dir-and-base-client (project-dir base-lsp-client)
+(defun lsp-docker--create-activation-function-by-project-dir-and-base-client (project-dir base-lsp-client)
   `(lambda (current-file-name current-major-mode)
      (let ((current-project-root (lsp-workspace-root))
            (registered-project-root ,project-dir)
@@ -507,7 +507,7 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
           (user-error "Cannot register a server with a missing image!"))
       (user-error "Cannot find the image %s but cannot build it too (missing Dockerfile)" image-name))))
 
-(defmacro lsp-docker--create-building-process-sentinel (server-id docker-server-id path-mappings image-name docker-container-name activation-fn server-command)
+(defun lsp-docker--create-building-process-sentinel (server-id docker-server-id path-mappings image-name docker-container-name activation-fn server-command)
   `(lambda (proc _message)
      (when (eq (process-status proc) 'exit)
        (lsp-docker-register-client-with-activation-fn
@@ -549,7 +549,14 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
                  :name "lsp-docker-build"
                  :buffer (current-buffer)
                  :command build-command-decoded
-                 :sentinel (lsp-docker--create-building-process-sentinel server-id docker-server-id path-mappings image-name docker-container-name activation-fn server-command))))
+                 :sentinel (lsp-docker--create-building-process-sentinel
+                            server-id
+                            docker-server-id
+                            path-mappings
+                            image-name
+                            docker-container-name
+                            activation-fn
+                            server-command))))
           (user-error "Cannot register a server with a missing image!"))
       (user-error "Cannot find the image %s but cannot build it too (missing Dockerfile)" image-name))))
 

--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -384,6 +384,18 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
            (registered-project-root ,project-dir))
        (f-same? current-project-root registered-project-root))))
 
+(defmacro lsp-docker--create-activation-function-by-project-dir-and-base-client (project-dir base-lsp-client)
+  `(lambda (current-file-name current-major-mode)
+     (let ((current-project-root (lsp-workspace-root))
+           (registered-project-root ,project-dir)
+           (base-activation-fn (lsp--client-activation-fn ,base-lsp-client))
+           (base-major-modes (lsp--client-major-modes ,base-lsp-client)))
+       (and (f-same? current-project-root registered-project-root)
+            (or (if (functionp base-activation-fn)
+                    (funcall base-activation-fn current-file-name current-major-mode)
+                  nil)
+                (-contains? base-major-modes current-major-mode))))))
+
 (defun lsp-docker-generate-docker-server-id (config project-root)
   "Generate the docker-server-id from the project config"
   (let ((original-server-id (symbol-name (lsp-docker-get-server-id config)))

--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -339,6 +339,13 @@ the docker container to run the language server."
         (intern (gethash 'server lsp-server-info))
       (gethash 'server lsp-server-info))))
 
+(defun lsp-docker--get-base-client (config)
+  "Get the base lsp client for dockerized client to be built upon"
+  (if-let* ((base-server-id (lsp-docker-get-server-id config))
+            (base-client (gethash server-id lsp-clients)))
+      base-client
+    (user-error "Cannot find a specified base lsp client! Please check the 'server' parameter in the config")))
+
 (defun lsp-docker-get-path-mappings (config project-directory)
   "Get the server path mappings"
   (if-let ((lsp-mappings-info (gethash 'mappings config)))


### PR DESCRIPTION
Don't just check that the file belongs to a registered project, but also:

1. Call the original client's (whose id was specified in the config or via `.dir-locals`) activation function;
2. Check that there is a match between major modes supported by the client and file being opened (checks were copied from the original `lsp-mode`).