### PR TITLE
fix: Drop support for Emacs 26.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         emacs-version:
-          - 26.3
           - 27.2
           - 28.2
           - 29.1

--- a/Eask
+++ b/Eask
@@ -12,7 +12,7 @@
 (source "gnu")
 (source "melpa")
 
-(depends-on "emacs" "25.1")
+(depends-on "emacs" "27.1")
 (depends-on "dash")
 (depends-on "lsp-mode")
 (depends-on "f")

--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/emacs-lsp/lsp-docker
 ;; Keywords: languages langserver
 ;; Version: 1.0.0
-;; Package-Requires: ((emacs "26.1") (dash "2.14.1") (lsp-mode "6.2.1") (f "0.20.0") (s "1.13.0") (yaml "0.2.0") (ht "2.0"))
+;; Package-Requires: ((emacs "27.1") (dash "2.14.1") (lsp-mode "6.2.1") (f "0.20.0") (s "1.13.0") (yaml "0.2.0") (ht "2.0"))
 
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
See https://github.com/emacs-lsp/lsp-mode/pull/4126.