### PR TITLE
fix: fixed not being able to start multiple containers for client

### DIFF
--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -166,9 +166,7 @@ Argument SERVER-COMMAND the command to execute inside the running container."
                                                           (puthash (lsp--workspace-root workspace)
                                                                    docker-container-name-full
                                                                    root-name-map)
-                      1                                    (funcall connect-fun filter sentinel name environment-fn workspace)
-                                                          )
-                                                        )
+                      1                                   (funcall connect-fun filter sentinel name environment-fn workspace)))
                                                       :test? (lambda (&rest _)
                                                               (-any?
                                                                (-lambda ((dir))


### PR DESCRIPTION
fix for https://github.com/emacs-lsp/lsp-docker/issues/48

The issue was that every time a new connection is requested to the lsp-server a new server process and thus a new container should be created.  However, since the containers are identified by name, a suffix must be appended to the name each time a container is created.  This was slightly complicated to handle due to the fact that the container name was needed to convert uri's to paths, however the hooks used to do this did not receive the workspace and as a result it was impossible to tell which container the uri's belong to.

The solution to this was to associate each container with the root directory of the workspace that they were created for.  Thus to do a URI to path conversion all that is necessary is to look up which root directory the path belongs to and then look up the container that serves that root directory.  To do this, the hook for registering the lsp-clients was modified so that when a new connection is connected, the suffix is incremented and the name of the new container is added to a hashmap with the root directory as a key.  Then the uri to path hooks were modified to search through the keys of this map to find which one matches the start of the path the URI converts to, and lookup the correct container name to do the full conversion.

In order to get the workspace when a new connection is requested, the full version of the hook was needed instead of just the options exposed by lsp-stdio-connection.  As a result, the function returned by lsp-stdio-connection was wrapped by a function that handles registering the container with the workspace's root directory.