### PR TITLE
Add the quote to avoid evaluating the list of LSP major mode

### DIFF
--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -397,7 +397,7 @@ Argument DOCKER-CONTAINER-NAME name to use for container."
      (let ((current-project-root (lsp-workspace-root))
            (registered-project-root ,project-dir)
            (base-activation-fn ,(lsp--client-activation-fn base-lsp-client))
-           (base-major-modes ,(lsp--client-major-modes base-lsp-client)))
+           (base-major-modes ',(lsp--client-major-modes base-lsp-client)))
        (and (f-same? current-project-root registered-project-root)
             (or (if (functionp base-activation-fn)
                     (funcall base-activation-fn current-file-name current-major-mode)


### PR DESCRIPTION
If LSP client has `:major-modes` (e.g., `:major-modes '(perl-mode cperl-mode)`), `lsp-docker--create-activation-function-by-project-dir-and-base-client` will return a function like below: When this function is called, `major-modes` list will be evaluated. It caused an error.

```elisp
(lambda (current-file-name current-major-mode)
  (let ((current-project-root (lsp-workspace-root))
        (registered-project-root ,project-dir)
        (base-activation-fn nil)                   ; ,(lsp--client-activation-fn base-lsp-client) => nil
        (base-major-modes (perl-mode cperl-mode))) ; ,(lsp--client-major-modes base-lsp-client)   => (perl-mode cperl-mode)
    (and (f-same? current-project-root registered-project-root)
         (or (if (functionp base-activation-fn)
                 (funcall base-activation-fn current-file-name current-major-mode)
               nil)
             (-contains? base-major-modes current-major-mode)))))
```