### PR TITLE
Add (docker or podman) launch parameters support

### DIFF
--- a/README.org
+++ b/README.org
@@ -166,6 +166,12 @@ It is structured in the following way:
       # source:
       # https://stackoverflow.com/questions/17066169/retrieve-keys-from-hash-table-sorted-by-the-values-efficiently
       server: server-id-of-the-base-server
+      # an (optional) array of parameters (docker or podman) to launch the image with
+      # initially intended to host the '--userns' parameter
+      # NOTE: 'launch_parameters' are not used with 'container' subtype servers
+      # in this case embed all required parameters when creating the server instead
+      launch_parameters:
+        - "--userns=nomap"
       # command to launch the language server in stdio mode
       # NOTE: 'launch_command' is not used with 'container' subtype servers as a command is embedded in a
       # container itself and serves as entrypoint

--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -81,6 +81,10 @@ name of the container/image for the described language server.")
   "Server ID of a registered LSP server. You can find the list of
 registered servers evaluating: `(ht-keys lsp-clients)'.")
 
+(defconst lsp-docker--srv-cfg-launch-parameters-key 'launch_parameters
+  "Command parameters (docker or podman) to launch the language server with.
+Pay attention that these parameters have to be supported by the selected subtype.")
+
 (defconst lsp-docker--srv-cfg-launch-command-key 'launch_command
   "Command to launch the language server in stdio mode. This key is
 not used when the `lsp-docker--srv-cfg-subtype-key' is set to
@@ -371,6 +375,9 @@ be bigger than default servers in order to override them)")
     (if (equal lsp-server-subtype "image")
         (gethash 'name server-config))))
 
+(defun lsp-docker--get-server-launch-parameters (server-config)
+  "Get the server launch parameters from the SERVER-CONFIG hash-table"
+  (gethash lsp-docker--srv-cfg-launch-parameters-key server-config))
 
 (defun lsp-docker-get-server-id (server-config)
   "Get the server id from the SERVER-CONFIG hash-table"

--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -377,7 +377,11 @@ be bigger than default servers in order to override them)")
 
 (defun lsp-docker--get-server-launch-parameters (server-config)
   "Get the server launch parameters from the SERVER-CONFIG hash-table"
-  (gethash lsp-docker--srv-cfg-launch-parameters-key server-config))
+  (let ((launch-parameters (gethash lsp-docker--srv-cfg-launch-parameters-key server-config)))
+    (if (or (vectorp launch-parameters)
+            (not launch-parameters))
+        launch-parameters
+      (user-error "Cannot find the right launch parameters"))))
 
 (defun lsp-docker-get-server-id (server-config)
   "Get the server id from the SERVER-CONFIG hash-table"

--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -164,6 +164,7 @@ Argument SERVER-COMMAND the command to execute inside the running container."
 (cl-defun lsp-docker-register-client (&key server-id
                                            docker-server-id
                                            path-mappings
+                                           launch-parameters
                                            docker-image-id
                                            docker-container-name
                                            priority
@@ -184,6 +185,7 @@ Argument SERVER-COMMAND the command to execute inside the running container."
                                                         (funcall (or launch-server-cmd-fn #'lsp-docker-launch-new-container)
                                                                  docker-container-name-full
                                                                  path-mappings
+                                                                 launch-parameters
                                                                  docker-image-id
                                                                  server-command)))
                                                      :test? (lambda (&rest _)
@@ -286,6 +288,7 @@ the docker container to run the language server."
                                   default-docker-container-name)
          :server-command server-command
          :path-mappings path-mappings
+         :launch-parameters nil
          :launch-server-cmd-fn #'lsp-docker-launch-new-container))
       client-configs)))
 
@@ -593,6 +596,7 @@ output)"
                                                      server-id
                                                      docker-server-id
                                                      path-mappings
+                                                     launch-parameters
                                                      image-name
                                                      docker-container-name
                                                      activation-fn
@@ -603,6 +607,7 @@ output)"
         :server-id ',server-id
         :docker-server-id ',docker-server-id
         :path-mappings ',path-mappings
+        :launch-parameters ,launch-parameters
         :docker-image-id ',image-name
         :docker-container-name ',docker-container-name
         :activation-fn ,activation-fn
@@ -615,6 +620,7 @@ output)"
                                                                   server-id
                                                                   docker-server-id
                                                                   path-mappings
+                                                                  launch-parameters
                                                                   docker-container-name
                                                                   activation-fn
                                                                   server-command
@@ -644,6 +650,7 @@ output)"
                             server-id
                             docker-server-id
                             path-mappings
+                            launch-parameters
                             image-name
                             docker-container-name
                             activation-fn
@@ -654,6 +661,7 @@ output)"
 (cl-defun lsp-docker-register-client-with-activation-fn (&key server-id
                                                               docker-server-id
                                                               path-mappings
+                                                              launch-parameters
                                                               docker-image-id
                                                               docker-container-name
                                                               activation-fn
@@ -675,6 +683,7 @@ output)"
                                                       (funcall (or launch-server-cmd-fn #'lsp-docker-launch-new-container)
                                                                docker-container-name
                                                                path-mappings
+                                                               launch-parameters
                                                                docker-image-id
                                                                server-command)))
                                                    :test? (lambda (&rest _)
@@ -700,6 +709,7 @@ dockerized server."
          (server-image-name (lsp-docker-get-server-image-name server-config))
          (regular-server-id (lsp-docker-get-server-id server-config))
          (server-id (lsp-docker-generate-docker-server-id server-config (lsp-workspace-root)))
+         (server-launch-parameters (lsp-docker--get-server-launch-parameters server-config))
          (server-launch-command (lsp-docker-get-launch-command server-config))
          (base-client (lsp-docker--get-base-client regular-server-id))
          (activation-fn (lsp-docker--create-activation-function-by-project-dir-and-base-client
@@ -720,6 +730,7 @@ dockerized server."
                                     :server-id regular-server-id
                                     :docker-server-id server-id
                                     :path-mappings path-mappings
+                                    :launch-parameters server-launch-parameters
                                     :docker-image-id server-image-name
                                     :docker-container-name server-container-name
                                     :activation-fn activation-fn
@@ -732,6 +743,7 @@ dockerized server."
                                   :server-id regular-server-id
                                   :docker-server-id server-id
                                   :path-mappings path-mappings
+                                  :launch-parameters server-launch-parameters
                                   :docker-container-name server-container-name
                                   :activation-fn activation-fn
                                   :server-command server-launch-command)))
@@ -740,6 +752,7 @@ dockerized server."
                                         :server-id regular-server-id
                                         :docker-server-id server-id
                                         :path-mappings path-mappings
+                                        :launch-parameters nil
                                         :docker-image-id nil
                                         :docker-container-name server-container-name
                                         :activation-fn activation-fn


### PR DESCRIPTION
Launch parameters are inserted into the command line after the path mappings.

They are not meant to be used with the `container` language server subtype