### PR TITLE
Use proper container launch options that work both for docker and podman

### DIFF
--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -441,7 +441,7 @@ Make sure the '%s' sub-key is set to one of the lsp registered clients:\n\n%s"
   "Return the docker command to be executed on host.
 Argument DOCKER-CONTAINER-NAME name to use for container."
   (split-string
-   (format "%s start -i %s"
+   (format "%s start -ia %s"
            lsp-docker-command
            docker-container-name)
    " "))


### PR DESCRIPTION
Add an `--attach` or `-a` flag when launching containers.
Somehow launching without this flag used to work with docker but breaks podman containers.