### PR TITLE
Start containers with --pid=host

### DIFF
--- a/lsp-docker.el
+++ b/lsp-docker.el
@@ -288,7 +288,7 @@ the docker container to run the language server."
                                   default-docker-container-name)
          :server-command server-command
          :path-mappings path-mappings
-         :launch-parameters nil
+         :launch-parameters '("--pid=host")
          :launch-server-cmd-fn #'lsp-docker-launch-new-container))
       client-configs)))
 


### PR DESCRIPTION
The nodejs-based language servers periodically check if the PID of the starting process still exists. Without this switch, they exit after 3 seconds.